### PR TITLE
Fix build error (Ubuntu 23.04)

### DIFF
--- a/deps/aoo/lib/src/sync.hpp
+++ b/deps/aoo/lib/src/sync.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 
 // for shared_lock
+#include <mutex>
 #include <shared_mutex>
 
 namespace aoo {


### PR DESCRIPTION
```
root@aooserver:~/sonobus/aooserver/Builds/LinuxMakefile# CONFIG=Release make Compiling client.cpp
In file included from ../../deps/aoo/lib/src/client.hpp:10,
                 from ../../deps/aoo/lib/src/client.cpp:5:
../../deps/aoo/lib/src/sync.hpp:98:26: error: ‘unique_lock’ in namespace ‘std’ does not name a template type
   98 | using unique_lock = std::unique_lock<shared_mutex>;
      |                          ^~~~~~~~~~~
../../deps/aoo/lib/src/sync.hpp:12:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
   11 | #include <shared_mutex>
  +++ |+#include <mutex>
   12 |
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::do_disconnect(aoo::net::command_reason, int)’:
../../deps/aoo/lib/src/client.cpp:573:9: error: ‘unique_lock’ was not declared in this scope
  573 |         unique_lock lock(peerlock_);
      |         ^~~~~~~~~~~
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::handle_group_leave(const osc::ReceivedMessage&)’:
../../deps/aoo/lib/src/client.cpp:1077:9: error: ‘unique_lock’ was not declared in this scope
 1077 |         unique_lock lock(peerlock_); // writer lock!
      |         ^~~~~~~~~~~
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::handle_peer_add(const osc::ReceivedMessage&)’:
../../deps/aoo/lib/src/client.cpp:1136:5: error: ‘unique_lock’ was not declared in this scope
 1136 |     unique_lock lock(peerlock_); // writer lock!
      |     ^~~~~~~~~~~
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::handle_peer_remove(const osc::ReceivedMessage&)’:
../../deps/aoo/lib/src/client.cpp:1165:5: error: ‘unique_lock’ was not declared in this scope
 1165 |     unique_lock lock(peerlock_); // writer lock!
      |     ^~~~~~~~~~~
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::wait_for_event(float)’:
../../deps/aoo/lib/src/client.cpp:790:13: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  790 |         read(waitpipe_[0], &c, 1);
      |         ~~~~^~~~~~~~~~~~~~~~~~~~~
../../deps/aoo/lib/src/client.cpp: In member function ‘void aoo::net::client::signal()’:
../../deps/aoo/lib/src/client.cpp:1221:10: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1221 |     write(waitpipe_[1], "\0", 1);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:109: build/intermediate/Release/client_305e502e.o] Error 1
root@aooserver:~/sonobus/aooserver/Builds/LinuxMakefile#
```